### PR TITLE
whyred: ramdisk: fix idle_time node permissions

### DIFF
--- a/rootdir/root/init.target.rc
+++ b/rootdir/root/init.target.rc
@@ -115,6 +115,9 @@ on boot
     chown system system /persist/speccfg/submask
     chown system system /persist/speccfg/partition
 
+    chmod 0664 /sys/devices/virtual/graphics/fb0/idle_time
+    chown system graphics /sys/devices/virtual/graphics/fb0/idle_time
+
 # Touchscreen
     chown system system /sys/class/input/input2/wake_gesture
 


### PR DESCRIPTION
HWPrimary::SetIdleTimeoutMs: Unable to open /sys/devices/virtual/graphics/fb0/idle_time, node Permission denied